### PR TITLE
[FIX] Updates hashing and hashing functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ E-vote is written in PHP and works as an ordinary website. Therefore you just ha
   define("MYSQL_DB", "evote");
   define("MYSQL_HOST", "localhost");
   define("SUPERUSER", "superuser"); // This user can never be deleted
+  define("LOCAL_CONST_HASH_SALT"); // Used to hash personal codes (must be constant)
   ?>
   ```
 

--- a/data/evote.php
+++ b/data/evote.php
@@ -1,5 +1,6 @@
 <?php
 //require __DIR__."/slask.php";
+// Loading config files
 include $_SERVER['DOCUMENT_ROOT']."/data/config.php";
 //crypt($pass, '$6$'.$salt.'$');
 //crypt($pass, $hash) == $hash;
@@ -238,7 +239,7 @@ class Evote {
             }
         }
 
-        $hash = crypt($personal_code, "duvetvad");
+        $hash = crypt($personal_code, LOCAL__CONST_HASH_SALT); // LOCAL_CONST_HASH_SALT is generated to data/config.php
         $sql2 = "SELECT id FROM elections_codes WHERE (code=\"$hash\" AND active IS NULL)";
         $r2 = $conn->query($sql2);
         $personal_code_ok = FALSE;
@@ -403,7 +404,7 @@ class Evote {
         $sql = "INSERT INTO elections_codes (code, active) VALUES ";
         $count = 0;
         foreach($codes as $c){
-            $hash = crypt($c, "duvetvad");
+            $hash = crypt($c, LOCAL_CONST_HASH_SALT); // Generated to data/config.php on setup
             if($count == 0){
                 $sql .= "(\"$hash\", NULL)";
             }else{

--- a/data/evote.php
+++ b/data/evote.php
@@ -239,7 +239,7 @@ class Evote {
             }
         }
 
-        $hash = crypt($personal_code, LOCAL__CONST_HASH_SALT); // LOCAL_CONST_HASH_SALT is generated to data/config.php
+        $hash = crypt($personal_code, LOCAL_CONST_HASH_SALT); // LOCAL_CONST_HASH_SALT is generated to data/config.php by setup.py
         $sql2 = "SELECT id FROM elections_codes WHERE (code=\"$hash\" AND active IS NULL)";
         $r2 = $conn->query($sql2);
         $personal_code_ok = FALSE;

--- a/install/setup.php
+++ b/install/setup.php
@@ -28,13 +28,37 @@ if (isset($_POST['db_host']) &&
     if ($db_host != '' && $db_name != '' && $db_user != '' && $db_pass != '' && $su_name != '' && $su_pass1 != '' && $su_pass2 != '') {
         if ($su_pass1 == $su_pass2) {
 
+            // Generate strong constant salt, taken from PHP forums
+            function generateRandomToken($length = 32){
+                if(!isset($length) || intval($length) <= 8 ){
+                  $length = 32;
+                }
+                if (function_exists("random_bytes")) {
+                    return bin2hex(random_bytes($length));
+                }
+                if (function_exists("mcrypt_create_iv")) {
+                    return bin2hex(mcrypt_create_iv($length, MCRYPT_DEV_URANDOM));
+                }
+                if (function_exists("openssl_random_pseudo_bytes")) {
+                    return bin2hex(openssl_random_pseudo_bytes($length));
+                }
+            }
+            
+            function generateSalt(){
+                // $6$ denotes SHA-512
+                return "$6$".substr(strtr(base64_encode(hex2bin(generateRandomToken(32))), "+", "."), 0, 44)."$";
+            }
 
+            $local_const_hash_salt = generateSalt();
+
+            // Content of config.php
             $content = "<?php\n";
             $content .= "define(\"MYSQL_PASS\", \"$db_pass\");\n";
             $content .= "define(\"MYSQL_USER\", \"$db_user\");\n";
             $content .= "define(\"MYSQL_DB\", \"$db_name\");\n";
             $content .= "define(\"MYSQL_HOST\", \"$db_host\");\n";
             $content .= "define(\"SUPERUSER\", \"$su_name\");\n";
+            $content .= "define(\"LOCAL_CONST_HASH_SALT\", \"$local_const_hash_salt\");\n"; // Used for personal codes, needs to be constant
             $content .= '?>';
 
             $file = fopen($filename, 'w') or die('Unable to open file!');


### PR DESCRIPTION
The old code used SHA-512, but used the risky `crypt()` function. This works, but is vulnerable for timing attacks.

All uses, where possible, of `crypt()` has been replaced by `password_hash()` and `password_verify()`.

The algorithm has been set to `PASSWORD_DEFAULT`, i.e. will be updated as server PHP is updated. Current hashing is `PASSWORD_BCRYPT` (`CRYPT_BLOWFISH`). Thiss should be seen as acceptable.

At two points `crypt()` is needed; for personal code hashing. This is because these two uses need a constant hash (we are searching the database for these hashes). However, in the old code, this was solved by a hardcoded salt. This is not terrible (since personal codes are not used for very long), but not great. I added code in `install/setup.php` to generate a constant local salt.

I have tested locally and it seems to work :)