### PR TITLE
[BUGFIX] Fixes bug which made pepper not work

### DIFF
--- a/install/setup.php
+++ b/install/setup.php
@@ -46,7 +46,7 @@ if (isset($_POST['db_host']) &&
             
             function generatePepper(){
                 // $6$ denotes SHA-512
-                return "$6$".substr(strtr(base64_encode(hex2bin(generateRandomToken(32))), "+", "."), 0, 44)."$";
+                return substr(strtr(base64_encode(hex2bin(generateRandomToken(32))), "+", "."), 0, 44);
             }
 
             $local_const_hash_pepper = generatePepper();
@@ -58,7 +58,7 @@ if (isset($_POST['db_host']) &&
             $content .= "define(\"MYSQL_DB\", \"$db_name\");\n";
             $content .= "define(\"MYSQL_HOST\", \"$db_host\");\n";
             $content .= "define(\"SUPERUSER\", \"$su_name\");\n";
-            $content .= "define(\"LOCAL_CONST_HASH_PEPPER\", \"$local_const_hash_pepper\");\n"; // Used for personal codes, needs to be constant
+            $content .= "define(\"LOCAL_CONST_HASH_PEPPER\", \"$6$\".\"$local_const_hash_pepper\".\"$\");\n"; // Used for personal codes, needs to be constant
             $content .= '?>';
 
             $file = fopen($filename, 'w') or die('Unable to open file!');


### PR DESCRIPTION
Fun fact: When `crypt()` generates hashed password, it uses the second
argument (a $salt) to decide which algorithm to use. `$6$` denotes
SHA-512.

However, in a string, using an unescaped $ means to insert a variable
until next breaking character. This means `"$6$dankmemes"` would be the
characters `$6` (a number can't start a character so this is "escaped")
followed by the variable $dankmemes. Yes, this is pretty damn stupid.

This should fix it by adding the SHA-512 characters in the config file,
not when generating it. 

I didn't see this earlier, since my test
generation started the pepper with a number i.e. properly escaped the
`$`...

One could ad the `$6$` when crypt is called, but this feels very clunky.