### PR TITLE
[BUGFIX] Removes references to $_SERVER['DOCUMENT_ROOT']

### DIFF
--- a/data/evote.php
+++ b/data/evote.php
@@ -1,6 +1,6 @@
 <?php
 // Loading config files
-include "./config.php";
+include "config.php";
 
 class Evote {
 

--- a/data/evote.php
+++ b/data/evote.php
@@ -1,6 +1,6 @@
 <?php
 // Loading config files
-include "../data/config.php";
+include "./config.php";
 
 class Evote {
 

--- a/data/evote.php
+++ b/data/evote.php
@@ -1,9 +1,7 @@
 <?php
-//require __DIR__."/slask.php";
 // Loading config files
-include $_SERVER['DOCUMENT_ROOT']."/data/config.php";
-//crypt($pass, '$6$'.$salt.'$');
-//crypt($pass, $hash) == $hash;
+include "../data/config.php";
+
 class Evote {
 
     private function connect(){

--- a/index.php
+++ b/index.php
@@ -18,7 +18,7 @@
 <?php
 session_start();
 
-include $_SERVER['DOCUMENT_ROOT'].'/data/evote.php';
+include 'data/evote.php';
 require 'index/classes/TableGenerator.php';
 require 'index/classes/MenuGenerator.php';
 require 'data/RandomInfo.php';
@@ -135,7 +135,7 @@ $randomString = new RandomInfo();
     if(isset($nav[1])){
         $page = $nav[1];
     }
-    $configured = file_exists($_SERVER['DOCUMENT_ROOT'].'/data/config.php');
+    $configured = file_exists('data/config.php');
     if(!$configured){
         echo '<h4>E-vote måste konfigureras</h4>';
     }elseif($module == 'vote'){

--- a/install/setup.php
+++ b/install/setup.php
@@ -1,10 +1,10 @@
 <?php
-require $_SERVER['DOCUMENT_ROOT'].'/data/RandomInfo.php';
-require $_SERVER['DOCUMENT_ROOT'].'/data/Dialogue.php';
+require '../data/RandomInfo.php';
+require '../data/Dialogue.php';
 $dialogue = new dialogue();
 
 $startup = true;
-$filename = $_SERVER['DOCUMENT_ROOT'].'/data/config.php';
+$filename = '../data/config.php';
 if (file_exists($filename)) {
     $startup = false;
 }
@@ -66,7 +66,7 @@ if (isset($_POST['db_host']) &&
             fclose($file);
             $dialogue->appendMessage('Konfigurationen lyckades!', 'success');
 
-            include $_SERVER['DOCUMENT_ROOT'].'/data/evote.php';
+            include '../data/evote.php';
             $evote = new Evote();
             if(!$evote->usernameExists($su_name)){
                 $evote->createNewUser($su_name, $su_pass1, 0);


### PR DESCRIPTION
There is no reason paths shouldn't be relative everywhere, makes it
possible to not install E-vote in the root of the PHP server