### PR TITLE
Feat start feedback

### DIFF
--- a/index/admin/electionControl.php
+++ b/index/admin/electionControl.php
@@ -37,13 +37,13 @@ if(in_array($priv, $access)){
 				<h4>Ett nytt val har skapats!</h4>
 			</div>
     	</div>
-		<scrip>
+		<script>
 		// Give user feedback of new election
 		function placeholder() {
 			document.getElementById("new-election-form").style.display = "none";
 			document.getElementById("submit-placeholder").style.display = "";
 		}
-		</scrip>
+		</script>
 
     <?php }else{
         ?>

--- a/index/admin/electionControl.php
+++ b/index/admin/electionControl.php
@@ -20,17 +20,17 @@ if(in_array($priv, $access)){
     	<div class="well" style="max-width: 400px">
 			<div id="new-election-form">
 				<form action="/actions/adminpagehandler.php" method="POST">
-				<div class="form-group">
-						<label for="vn">Namn på val:</label>
-						<input type="text" name="valnamn" class="form-control" id="vn" autocomplete="off">
-				</div>
-				<div class="form-group" style="max-width: 150px">
-						<label for="ap">Max antal personer:</label>
-						<input type="number" name="antal_personer" class="form-control" id="ap" min="1" autocomplete="off">
-				</div>
-				<input type="checkbox" id="csv_checkbox" name="csv_checkbox">
-				<label for="csv_checkbox">Få koder i CSV-format (för distansröstning)</label>
-				<button type="submit" onclick="placeholder()" class="btn btn-primary" value="create" name="button">Skapa</button>
+					<div class="form-group">
+							<label for="vn">Namn på val:</label>
+							<input type="text" name="valnamn" class="form-control" id="vn" autocomplete="off">
+					</div>
+					<div class="form-group" style="max-width: 150px">
+							<label for="ap">Max antal personer:</label>
+							<input type="number" name="antal_personer" class="form-control" id="ap" min="1" autocomplete="off">
+					</div>
+					<input type="checkbox" id="csv_checkbox" name="csv_checkbox">
+					<label for="csv_checkbox">Få koder i CSV-format (för distansröstning)</label>
+					<button type="submit" onclick="placeholder()" class="btn btn-primary" value="create" name="button">Skapa</button>
 				</form>
 			</div>
 			<div id="submit-placeholder" style="display: none">
@@ -55,11 +55,11 @@ if(in_array($priv, $access)){
     	<div class="well" style="max-width: 400px">
     		<form action="/actions/adminpagehandler.php" method="POST">
     			<div class="form-group">
-            <label for="psw1">Ditt lösenord:</label>
-            <input type="password" name="pswuser" class="form-control" id="psw1">
-    	</div>
-    	<button type="submit" class="btn btn-primary" value="delete_election" name="button">Stäng val</button>
-    	</form>
+            		<label for="psw1">Ditt lösenord:</label>
+            		<input type="password" name="pswuser" class="form-control" id="psw1">
+    			</div>
+    			<button type="submit" class="btn btn-primary" value="delete_election" name="button">Stäng val</button>
+    		</form>
     	</div>
         <?php
     }

--- a/index/admin/electionControl.php
+++ b/index/admin/electionControl.php
@@ -18,20 +18,32 @@ if(in_array($priv, $access)){
     	<h3>Skapa nytt val</h3>
     	<hr>
     	<div class="well" style="max-width: 400px">
-    	<form action="/actions/electionadminpagehandler.php" method="POST">
-    	<div class="form-group">
-    	        <label for="vn">Namn på val:</label>
-    	        <input type="text" name="valnamn" class="form-control" id="vn" autocomplete="off">
+			<div id="new-election-form">
+				<form action="/actions/electionadminpagehandler.php" method="POST">
+				<div class="form-group">
+						<label for="vn">Namn på val:</label>
+						<input type="text" name="valnamn" class="form-control" id="vn" autocomplete="off">
+				</div>
+				<div class="form-group" style="max-width: 150px">
+						<label for="ap">Max antal personer:</label>
+						<input type="number" name="antal_personer" class="form-control" id="ap" min="1" autocomplete="off">
+				</div>
+				<input type="checkbox" id="csv_checkbox" name="csv_checkbox">
+				<label for="csv_checkbox">Få koder i CSV-format (för distansröstning)</label>
+				<button type="submit" onclick="placeholder()" class="btn btn-primary" value="create" name="button">Skapa</button>
+				</form>
+			</div>
+			<div id="submit-placeholder" style="display: none">
+				<h4>Ett nytt val har skapats!</h4>
+			</div>
     	</div>
-    	<div class="form-group" style="max-width: 150px">
-    	        <label for="ap">Max antal personer:</label>
-    	        <input type="number" name="antal_personer" class="form-control" id="ap" min="1" autocomplete="off">
-    	</div>
-		<input type="checkbox" id="csv_checkbox" name="csv_checkbox">
-		<label for="csv_checkbox">Få koder i CSV-format (för distansröstning)</label>
-    	<button type="submit" class="btn btn-primary" value="create" name="button">Skapa</button>
-    	</form>
-    	</div>
+		<scrip>
+		// Give user feedback of new election
+		function placeholder() {
+			document.getElementById("new-election-form").style.display = "none";
+			document.getElementById("submit-placeholder").style.display = "";
+		}
+		</scrip>
 
     <?php }else{
         ?>

--- a/index/admin/electionControl.php
+++ b/index/admin/electionControl.php
@@ -40,10 +40,11 @@ if(in_array($priv, $access)){
 		<script>
 		// Give user feedback of new election
 		function placeholder() {
+			// Small timeout for server to catch up
 			setTimeout(() => {
 				document.getElementById("new-election-form").style.display = "none";
 				document.getElementById("submit-placeholder").style.display = "";
-			},200);
+			}, 450);
 		}
 		</script>
 

--- a/index/admin/electionControl.php
+++ b/index/admin/electionControl.php
@@ -40,8 +40,10 @@ if(in_array($priv, $access)){
 		<script>
 		// Give user feedback of new election
 		function placeholder() {
-			document.getElementById("new-election-form").style.display = "none";
-			document.getElementById("submit-placeholder").style.display = "";
+			setTimeout(() => {
+				document.getElementById("new-election-form").style.display = "none";
+				document.getElementById("submit-placeholder").style.display = "";
+			},200);
 		}
 		</script>
 


### PR DESCRIPTION
Got feedback from Kontaktorn at the org that the admin receives no feedback of an election being created when they choose to get the election codes in CSV format, except for the codes being sent to them. This adds some JavaScript to give instant feedback.

One might argue that saying "New election started!" without checking with the server is a bad idea, but oh well it's better than before.

Edit: If something went wrong, the server will respons pretty quickly. Added a small timeout before doing anything.