### PR TITLE
Fixes strange error page when failing to create election

### DIFF
--- a/actions/electionadminpagehandler.php
+++ b/actions/electionadminpagehandler.php
@@ -16,38 +16,6 @@ if(in_array($priv, $access)){
                 $input_ok = false;
                 $dialogue->appendMessage('Du har inte angett vad som ska väljas', 'error');
             }
-<<<<<<< HEAD
-        } else {
-            $_SESSION['message'] = serialize($dialogue);
-            header('Location: /adminmain/electioncontrol');
-        }
-    } elseif ($_POST['button'] == 'begin_round') { # STARTA NYTT VAL
-        $dialogue = new Dialogue();
-        $input_ok = true;
-        if ($_POST['round_name'] == '') {
-            $input_ok = false;
-            $dialogue->appendMessage('Du har inte angett vad som ska väljas', 'error');
-        }
-        if ($_POST['code'] == '') {
-            $input_ok = false;
-            $dialogue->appendMessage('Du har inte angett någon tillfällig kod', 'error');
-        }
-        if ($_POST['max_num'] == '') {
-            $input_ok = false;
-            $dialogue->appendMessage('Du har inte angett hur många man får rösta på', 'error');
-        }
-        if ($evote->ongoingRound()) {
-            $input_ok = false;
-            $dialogue->appendMessage('En valomgång är redan igång', 'error');
-        }
-
-        $cands[0] = '';
-        $n = 0;
-        foreach ($_POST['candidates'] as $name) {
-            if ($name != '') {
-                $cands[$n] = $name;
-                ++$n;
-=======
             if ($_POST['code'] == '') {
                 $input_ok = false;
                 $dialogue->appendMessage('Du har inte angett någon tillfällig kod', 'error');
@@ -59,7 +27,6 @@ if(in_array($priv, $access)){
             if ($evote->ongoingRound()) {
                 $input_ok = false;
                 $dialogue->appendMessage('En valomgång är redan igång', 'error');
->>>>>>> ca29b64dffcbae01de74186023e9a3f2acfc9dcf
             }
 
             $cands[0] = '';

--- a/actions/electionadminpagehandler.php
+++ b/actions/electionadminpagehandler.php
@@ -19,7 +19,7 @@ if(in_array($priv, $access)){
 <<<<<<< HEAD
         } else {
             $_SESSION['message'] = serialize($dialogue);
-            header('Location: /adminmain/electioncontrol');
+            header('Location: /electionadmin');
         }
     } elseif ($_POST['button'] == 'begin_round') { # STARTA NYTT VAL
         $dialogue = new Dialogue();

--- a/actions/electionadminpagehandler.php
+++ b/actions/electionadminpagehandler.php
@@ -42,7 +42,7 @@ if (isset($_POST['button'])) {
             }
         } else {
             $_SESSION['message'] = serialize($dialogue);
-            header('Location: /electionadmin');
+            header('Location: /adminmain/electioncontrol');
         }
     } elseif ($_POST['button'] == 'begin_round') { # STARTA NYTT VAL
         $dialogue = new Dialogue();

--- a/actions/electionadminpagehandler.php
+++ b/actions/electionadminpagehandler.php
@@ -19,7 +19,7 @@ if(in_array($priv, $access)){
 <<<<<<< HEAD
         } else {
             $_SESSION['message'] = serialize($dialogue);
-            header('Location: /electionadmin');
+            header('Location: /adminmain/electioncontrol');
         }
     } elseif ($_POST['button'] == 'begin_round') { # STARTA NYTT VAL
         $dialogue = new Dialogue();


### PR DESCRIPTION
Currently, if an election can't be created, the admin is redirected to a
page indicating they don't have access, since the election didn't start.
This instead redirects to the election creation page, with the proper
errors.