### PR TITLE
Hotfix election admin priv

### DIFF
--- a/actions/adminpagehandler.php
+++ b/actions/adminpagehandler.php
@@ -47,28 +47,28 @@ if(in_array($priv, $access)){
                 $_SESSION['message'] = serialize($dialogue);
                 header('Location: /electionadmin');
             }
-        }
-    } elseif ($_POST['button'] == 'delete_election') { # TA BORT VAL KNAPPEN
-        $dialogue = new Dialogue();
-        $input_ok = true;
-        if ($_POST['pswuser'] == '') {
-            $input_ok = false;
-            $dialogue->appendMessage('Alla fält är inte ifyllda', 'error');
-        }
-
-        $redirect = '';
-        if ($input_ok) {
-            $psw1 = $_POST['pswuser'];
-            $current_usr = $_SESSION['user'];
-            if ($evote->login($current_usr, $psw1)) {
-                $evote->endSession();
-                $dialogue->appendMessage('Valet är nu stängt', 'success');
-                $redirect = 'admin';
-            } else {
-                $dialogue->appendMessage('Fel lösenord och/eller användarnamn någonstans', 'error');
+        } elseif ($_POST['button'] == 'delete_election') { # TA BORT VAL KNAPPEN
+            $dialogue = new Dialogue();
+            $input_ok = true;
+            if ($_POST['pswuser'] == '') {
+                $input_ok = false;
+                $dialogue->appendMessage('Alla fält är inte ifyllda', 'error');
             }
+
+            $redirect = '';
+            if ($input_ok) {
+                $psw1 = $_POST['pswuser'];
+                $current_usr = $_SESSION['user'];
+                if ($evote->login($current_usr, $psw1)) {
+                    $evote->endSession();
+                    $dialogue->appendMessage('Valet är nu stängt', 'success');
+                    $redirect = 'admin';
+                } else {
+                    $dialogue->appendMessage('Fel lösenord och/eller användarnamn någonstans', 'error');
+                }
+            }
+            $_SESSION['message'] = serialize($dialogue);
+            header('Location: /adminmain');
         }
-        $_SESSION['message'] = serialize($dialogue);
-        header('Location: /adminmain');
     }
 }

--- a/actions/adminpagehandler.php
+++ b/actions/adminpagehandler.php
@@ -8,43 +8,66 @@ $access = array(0);
 $priv = $evote->getPrivilege($_SESSION["user"]);
 if(in_array($priv, $access)){
     if (isset($_POST['button'])) {
-        if ($_POST['button'] == 'login') {
+        if ($_POST['button'] == 'create') { # CREATE NEW ELECTION
+            $dialogue = new Dialogue();
             $input_ok = true;
             $msg = '';
             $msgType = '';
-            if ($_POST['usr'] == '') {
+            if ($_POST['valnamn'] == '') {
                 $input_ok = false;
-                $msg .= 'Du har inte skrivit in något användarnamn. ';
-                $msgType = 'error';
+                $dialogue->appendMessage('Du har inte angett något namn på valet', 'error');
             }
-            if ($_POST['psw'] == '') {
+            if ($_POST['antal_personer'] == '') {
                 $input_ok = false;
-                $msg .= 'Du har inte angett något lösenord ';
-                $msgType = 'error';
+                $dialogue->appendMessage('Du har inte angett det maximala antalet personer', 'error');
+            }
+            if ($evote->ongoingSession()) {
+                $input_ok = false;
+                $dialogue->appendMessage('Det pågår redan ett val', 'error');
             }
 
             if ($input_ok) {
-                $usr = $_POST['usr'];
-                $psw = $_POST['psw'];
-                $correct = $evote->login($usr, $psw); # Kolla lösenordet mot databases. Detta sker i data/evote.php
+                $dialogue->setMessageType('success');
+                $name = $_POST['valnamn'];
+                $nop = $_POST['antal_personer'];
 
-                if ($correct) {
-                    $_SESSION['superuser'] = $usr;
+                require '../ecrypt.php';
+                $ecrypt = new ECrypt();
+                $codes = $ecrypt->generate_otp($nop);
+                $evote->newCodes($codes);
+                $evote->newSession($name);
+                // Om man har distansval vill man ha CSV-fil istället
+                if (isset($_POST['csv_checkbox'])) {
+                    include 'csvcodesend.php';
                 } else {
-                    $msg .= 'Användarnamet och/eller lösenordet är fel. ';
-                    $msgType = 'error';
+                    include 'codeprint.php';
                 }
+            } else {
+                $_SESSION['message'] = serialize($dialogue);
+                header('Location: /electionadmin');
             }
-
-            $_SESSION['superuser'] = $_POST['usr'];
-            $_SESSION['message'] = array('type' => $msgType, 'message' => $msg);
-            echo $_SESSION['superuser'];
-            header('Location: /adminaccount');
-
-
-        } elseif ($_POST['button'] == 'logout') {
-            unset($_SESSION['superuser']);
-            header('Location: /adminaccount');
         }
+    } elseif ($_POST['button'] == 'delete_election') { # TA BORT VAL KNAPPEN
+        $dialogue = new Dialogue();
+        $input_ok = true;
+        if ($_POST['pswuser'] == '') {
+            $input_ok = false;
+            $dialogue->appendMessage('Alla fält är inte ifyllda', 'error');
+        }
+
+        $redirect = '';
+        if ($input_ok) {
+            $psw1 = $_POST['pswuser'];
+            $current_usr = $_SESSION['user'];
+            if ($evote->login($current_usr, $psw1)) {
+                $evote->endSession();
+                $dialogue->appendMessage('Valet är nu stängt', 'success');
+                $redirect = 'admin';
+            } else {
+                $dialogue->appendMessage('Fel lösenord och/eller användarnamn någonstans', 'error');
+            }
+        }
+        $_SESSION['message'] = serialize($dialogue);
+        header('Location: /adminmain');
     }
 }

--- a/actions/adminpagehandler.php
+++ b/actions/adminpagehandler.php
@@ -2,6 +2,7 @@
 
 session_start();
 require '../data/evote.php';
+require '../data/Dialogue.php';
 $evote = new Evote();
 
 $access = array(0);

--- a/actions/electionadminpagehandler.php
+++ b/actions/electionadminpagehandler.php
@@ -9,45 +9,7 @@ $access = array(1);
 $priv = $evote->getPrivilege($_SESSION["user"]);
 if(in_array($priv, $access)){
     if (isset($_POST['button'])) {
-        if ($_POST['button'] == 'create') { # SKAPA NYTT VAL
-            $dialogue = new Dialogue();
-            $input_ok = true;
-            $msg = '';
-            $msgType = '';
-            if ($_POST['valnamn'] == '') {
-                $input_ok = false;
-                $dialogue->appendMessage('Du har inte angett något namn på valet', 'error');
-            }
-            if ($_POST['antal_personer'] == '') {
-                $input_ok = false;
-                $dialogue->appendMessage('Du har inte angett det maximala antalet personer', 'error');
-            }
-            if ($evote->ongoingSession()) {
-                $input_ok = false;
-                $dialogue->appendMessage('Det pågår redan ett val', 'error');
-            }
-
-            if ($input_ok) {
-                $dialogue->setMessageType('success');
-                $name = $_POST['valnamn'];
-                $nop = $_POST['antal_personer'];
-
-                require '../ecrypt.php';
-                $ecrypt = new ECrypt();
-                $codes = $ecrypt->generate_otp($nop);
-                $evote->newCodes($codes);
-                $evote->newSession($name);
-                // Om man har distansval vill man ha CSV-fil istället
-                if (isset($_POST['csv_checkbox'])) {
-                    include 'csvcodesend.php';
-                } else {
-                    include 'codeprint.php';
-                }
-            } else {
-                $_SESSION['message'] = serialize($dialogue);
-                header('Location: /electionadmin');
-            }
-        } elseif ($_POST['button'] == 'begin_round') { # STARTA NYTT VAL
+         if ($_POST['button'] == 'begin_round') { # STARTA NYTT VAL
             $dialogue = new Dialogue();
             $input_ok = true;
             if ($_POST['round_name'] == '') {
@@ -99,30 +61,6 @@ if(in_array($priv, $access)){
         } elseif ($_POST['button'] == 'end_round') { # AVSLUTA VALOMGÅNG KNAPPEN
                     $evote->endRound();
             header('Location: /electionadmin');
-
-
-        } elseif ($_POST['button'] == 'delete_election') { # TA BORT VAL KNAPPEN
-            $dialogue = new Dialogue();
-            $input_ok = true;
-            if ($_POST['pswuser'] == '') {
-                $input_ok = false;
-                $dialogue->appendMessage('Alla fält är inte ifyllda', 'error');
-            }
-
-            $redirect = '';
-            if ($input_ok) {
-                $psw1 = $_POST['pswuser'];
-                $current_usr = $_SESSION['user'];
-                if ($evote->login($current_usr, $psw1)) {
-                    $evote->endSession();
-                    $dialogue->appendMessage('Valet är nu stängt', 'success');
-                    $redirect = 'admin';
-                } else {
-                    $dialogue->appendMessage('Fel lösenord och/eller användarnamn någonstans', 'error');
-                }
-            }
-            $_SESSION['message'] = serialize($dialogue);
-            header('Location: /adminmain');
-        }
+        } 
     }
 }

--- a/index/admin/electionControl.php
+++ b/index/admin/electionControl.php
@@ -18,7 +18,7 @@ if(in_array($priv, $access)){
     	<h3>Skapa nytt val</h3>
     	<hr>
     	<div class="well" style="max-width: 400px">
-    	<form action="/actions/electionadminpagehandler.php" method="POST">
+    	<form action="/actions/adminpagehandler.php" method="POST">
     	<div class="form-group">
     	        <label for="vn">Namn på val:</label>
     	        <input type="text" name="valnamn" class="form-control" id="vn" autocomplete="off">
@@ -38,7 +38,7 @@ if(in_array($priv, $access)){
         <h3>Stäng nuvarande val</h3>
     	<hr>
     	<div class="well" style="max-width: 400px">
-    		<form action="/actions/electionadminpagehandler.php" method="POST">
+    		<form action="/actions/adminpagehandler.php" method="POST">
     			<div class="form-group">
             <label for="psw1">Ditt lösenord:</label>
             <input type="password" name="pswuser" class="form-control" id="psw1">
@@ -52,5 +52,4 @@ if(in_array($priv, $access)){
 } else {
     echo "Du har inte behörighet att visa denna sida";
 }
-
- ?>
+?>


### PR DESCRIPTION
For some reason, handling opening and closing election sessions (not rounds!) were handled by `actions/electionadminpagehandler.php`, but `$priv == 0` was needed (admin status). This fix moves the code to `actions/adminpagehandler.php` where correct checks are made, and removes the old unused code in the same file (the code were set to be removed in #11)