### PR TITLE
[FIX] Remove old dialouge

### DIFF
--- a/actions/adminpagehandler.php
+++ b/actions/adminpagehandler.php
@@ -13,8 +13,6 @@ if(in_array($priv, $access)){
         if ($_POST['button'] == 'create') { # CREATE NEW ELECTION
             $dialogue = new Dialogue();
             $input_ok = true;
-            $msg = '';
-            $msgType = '';
             if ($_POST['valnamn'] == '') {
                 $input_ok = false;
                 $dialogue->appendMessage(getLocalizedText('You have not entered a name for the election'), 'error');

--- a/actions/useradminpagehandler.php
+++ b/actions/useradminpagehandler.php
@@ -14,19 +14,13 @@ if(in_array($priv, $access)){
         if ($_POST['button'] == 'change') {
             $dialogue = new dialogue();
             $input_ok = true;
-            $msg = '';
-            $msgType = '';
             if ($_POST['psw'] == '' || $_POST['username'] == '') {
                 $input_ok = false;
                 $dialogue->appendMessage(getLocalizedText('One or more of the fields were empty'), 'error');
-                $msg .= getLocalizedText('One or more of the fields were empty').'. ';
-                $msgType = 'error';
             }
             if (!$evote->usernameExists($_POST['username'])) {
                 $input_ok = false;
                 $dialogue->appendMessage(getLocalizedText('The username you entered already exists'), 'error');
-                $msg .= getLocalizedText('The username you entered already exists').'. ';
-                $msgType = 'error';
             }
 
             if ($input_ok) {
@@ -35,28 +29,19 @@ if(in_array($priv, $access)){
                 $evote->newPassword($user, $psw);
 
                 $dialogue->appendMessage(getLocalizedText('The password has been changed'), 'success');
-                $msg .= getLocalizedText('The password has been changed').'. ';
-                $msgType = 'success';
             }
-            $_SESSION['message'] = array('type' => $msgType, 'message' => $msg);
             $_SESSION['message'] = serialize($dialogue);
             header('Location: /useradmin/changepassword');
         } elseif ($_POST['button'] == 'new') {
             $dialogue = new dialogue();
             $input_ok = true;
-            $msg = '';
-            $msgType = '';
             if ($_POST['psw'] == '' || $_POST['username'] == '' || $_POST['priv'] == '') {
                 $input_ok = false;
                 $dialogue->appendMessage(getLocalizedText('One or more of the fields were empty'), 'error');
-                $msg .= getLocalizedText('One or more of the fields were empty').'. ';
-                $msgType = 'error';
             }
             if ($evote->usernameExists($_POST['username'])) {
                 $input_ok = false;
                 $dialogue->appendMessage(getLocalizedText('The username you entered already exists'), 'error');
-                $msg .= getLocalizedText('The username you entered already exists').'. ';
-                $msgType = 'error';
             }
 
             if ($input_ok) {
@@ -65,10 +50,7 @@ if(in_array($priv, $access)){
                 $priv = $_POST['priv'];
                 $evote->createNewUser($user, $psw, $priv);
                 $dialogue->appendMessage(getLocalizedText('A new user has been created'), 'success');
-                $msg .= getLocalizedText('A new user has been created').'. ';
-                $msgType = 'success';
             }
-            $_SESSION['message'] = array('type' => $msgType, 'message' => $msg);
             $_SESSION['message'] = serialize($dialogue);
             header('Location: /useradmin/newuser');
 
@@ -83,11 +65,8 @@ if(in_array($priv, $access)){
                 $msgType = 'success';
             } else {
                 $dialogue->appendMessage(getLocalizedText('You have not chosen any users to delete'), 'error');
-                $msg = getLocalizedText('You have not chosen any users to delete').'. ';
-                $msgType = 'error';
             }
 
-            $_SESSION['message'] = array('type' => $msgType, 'message' => $msg);
             $_SESSION['message'] = serialize($dialogue);
             header('Location: /useradmin');
         }

--- a/actions/usersessionhandler.php
+++ b/actions/usersessionhandler.php
@@ -12,8 +12,6 @@ if(isset($_POST["button"])){
 	if($_POST["button"]=="login"){
 		$dialogue = new Dialogue();
 		$input_ok = TRUE;
-		$msg = "";
-		$msgType = "";
 		if($_POST["usr"] == ""){
 			$input_ok = FALSE;
 			$dialogue->appendMessage(getLocalizedText('You have not entered any username'), 'error');

--- a/data/Dialogue.php
+++ b/data/Dialogue.php
@@ -6,15 +6,6 @@ class Dialogue
     private $type = 'info';
     private $messages;
 
-    public function __construct()
-    {
-    }
-
-    public function appendMessage2($msg)
-    {
-        $this->message .= $msg.'. ';
-    }
-
     public function appendMessage($msg, $type)
     {
         if (!isset($this->messages)) {


### PR DESCRIPTION
All boxes with error messages are since long handled by `data/Dialouge.php`, but for some reason some files still use the old way of appending text to a variable but then just overwriting it (lol). This removes unused methods in `data/Dialouge.php` and removes unused variables in `actions/`